### PR TITLE
Make XEN support conditional to allow s390x and ppc64el to build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -189,7 +189,7 @@ parts:
       mkdir -p usr/local/lib/guestfs/appliance
       mkdir -p /snap/$SNAPCRAFT_PROJECT_NAME
       ln -sf $SNAPCRAFT_STAGE /snap/$SNAPCRAFT_PROJECT_NAME/current
-      env -i LIBGUESTFS_PATH=$SNAPCRAFT_STAGE/lib/guestfs LD_LIBRARY_PATH=$SNAPCRAFT_STAGE/lib:$SNAPCRAFT_STAGE/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAPCRAFT_STAGE/usr/lib:$SNAPCRAFT_STAGE/usr/lib/$SNAPCRAFT_ARCH_TRIPLET PATH=$SNAPCRAFT_STAGE/usr/sbin:$SNAPCRAFT_STAGE/usr/bin:$SNAPCRAFT_STAGE/sbin:$SNAPCRAFT_STAGE/bin:/usr/sbin:/usr/bin:/sbin:/bin libguestfs-make-fixed-appliance $SNAPCRAFT_PRIME/usr/local/lib/guestfs/appliance
+      env -i LIBGUESTFS_PATH=$SNAPCRAFT_STAGE/lib/guestfs LD_LIBRARY_PATH=$SNAPCRAFT_STAGE/lib:$SNAPCRAFT_STAGE/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAPCRAFT_STAGE/usr/lib:$SNAPCRAFT_STAGE/usr/lib/$SNAPCRAFT_ARCH_TRIPLET PATH=$SNAPCRAFT_STAGE/usr/sbin:$SNAPCRAFT_STAGE/usr/bin:$SNAPCRAFT_STAGE/sbin:$SNAPCRAFT_STAGE/bin:/usr/sbin:/usr/bin:/sbin:/bin LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1 libguestfs-make-fixed-appliance $SNAPCRAFT_PRIME/usr/local/lib/guestfs/appliance
       rm -f /snap/$SNAPCRAFT_PROJECT_NAME/current
       rmdir /snap/$SNAPCRAFT_PROJECT_NAME
       chmod 0644 usr/local/lib/guestfs/appliance/kernel

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -83,7 +83,6 @@ parts:
       - --disable-spice
       - --disable-curses
       - --enable-seccomp
-      - --enable-xen
       - --enable-xfsctl
       - --enable-kvm
       - --enable-vhost-net
@@ -108,6 +107,14 @@ parts:
       - libpixman-1-dev
       - python-all-dev
       - libglib2.0-dev
+      - on amd64:
+        - libxen-dev
+      - on arm64:
+        - libxen-dev
+      - on armhf:
+        - libxen-dev
+      - on i386:
+        - libxen-dev
     stage-packages:
       - seabios
       - ipxe-qemu
@@ -115,10 +122,17 @@ parts:
       - libnuma1
       - libaio1
       - libcurl3-gnutls
-      - libxen-dev
       - libcapstone3
       - libfdt1
       - libpixman-1-0
+      - on amd64:
+        - libxen-4.9
+      - on arm64:
+        - libxen-4.9
+      - on armhf:
+        - libxen-4.9
+      - on i386:
+        - libxen-4.9
   supermin:
     source: https://github.com/libguestfs/supermin.git
     source-type: git


### PR DESCRIPTION
Snapcraft currenty does not have support for conditional
configflags based on architecture. (LP: #1831752)

Luckily the QEMU configure script builds XEN support based on
presence of the libraries, so making that part conditional will do.