### PR TITLE
elements: Update apt cache before adding UCA

### DIFF
--- a/src/elements/ubuntu-cloud-archive/pre-install.d/42-ubuntu-cloud-archive
+++ b/src/elements/ubuntu-cloud-archive/pre-install.d/42-ubuntu-cloud-archive
@@ -3,6 +3,7 @@
 # Add the Ubuntu Cloud Archive
 
 if [ ! -z "${DIB_UBUNTU_CLOUD_ARCHIVE}" ]; then
+    apt-get update
     add-apt-repository cloud-archive:$DIB_UBUNTU_CLOUD_ARCHIVE
     apt-get update
 fi


### PR DESCRIPTION
In some circumstances the apt cache is not updated prior to running
the ``ubuntu-cloud-archive`` element.  Explicitly update the apt
cache in the element itself to avoid this issue.

Fixes #10