### PR TITLE
Add new element for tuning tools

### DIFF
--- a/src/elements/tuning/README.rst
+++ b/src/elements/tuning/README.rst
@@ -1,0 +1,1 @@
+Element to install performance troubleshooting tools, and additional kernel parameters.

--- a/src/elements/tuning/package-installs.yaml
+++ b/src/elements/tuning/package-installs.yaml
@@ -1,0 +1,4 @@
+sysstat:
+htop:
+ifstat:
+dstat:

--- a/src/elements/tuning/post-install.d/99-kernel-tuning
+++ b/src/elements/tuning/post-install.d/99-kernel-tuning
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+#Entries added to the elements provided in Octavia source
+
+sysctl-write-value net.ipv4.tcp_congestion_control bbr
+sysctl-write-value net.core.default_qdisc fq
+sysctl-write-value net.ipv4.tcp_syn_retries 3
+sysctl-write-value net.ipv4.neigh.default.gc_thresh1 128
+sysctl-write-value net.ipv4.neigh.default.gc_thresh2 28672
+sysctl-write-value net.ipv4.neigh.default.gc_thresh3 32768
+sysctl-write-value net.ipv6.neigh.default.gc_thresh1 128
+sysctl-write-value net.ipv6.neigh.default.gc_thresh2 28672
+sysctl-write-value net.ipv6.neigh.default.gc_thresh3 32768
+# It's ok for these to fail if conntrack module isn't loaded
+sysctl-write-value net.nf_conntrack_max 1000000  || true
+sysctl-write-value net.netfilter.nf_conntrack_max 1000000  || true

--- a/src/retrofit/retrofit.sh
+++ b/src/retrofit/retrofit.sh
@@ -93,7 +93,7 @@ virt-dib ${DEBUG} \
     ubuntu-ppa \
     haproxy-octavia rebind-sshd no-resolvconf amphora-agent \
     sos keepalived-octavia ipvsadmin pip-cache certs-ramfs \
-    ubuntu-amphora-agent
+    ubuntu-amphora-agent tuning
 
 virt-sysprep -a $TEMP_IMAGE_FILE \
     --operations tmp-files,customize \


### PR DESCRIPTION
Adds a new custom element that includes a few kernel tuning parameters,
and installs some performance monitoring tools for the purpose of tuning
amphora images.

Resolves https://github.com/openstack-charmers/octavia-diskimage-retrofit/issues/16