### PR TITLE
Fix retrofitting of Focal images

### DIFF
--- a/src/elements/ubuntu-amphora-agent/package-installs.yaml
+++ b/src/elements/ubuntu-amphora-agent/package-installs.yaml
@@ -1,3 +1,3 @@
 # The Octavia ``certs-ramfs`` element requires kernel modules that are
 # not available in the linux-image-virtual package at the moment
-linux-image-generic:
+linux-generic:

--- a/src/elements/ubuntu-amphora-agent/post-install.d/95-ubuntu-amphora-generic-kernel
+++ b/src/elements/ubuntu-amphora-agent/post-install.d/95-ubuntu-amphora-generic-kernel
@@ -1,7 +1,16 @@
 #!/bin/bash
 
+# The amphora requires the generic kernel to support storing cryptographic
+# keys in an encrypted ramfs.
+#
+# https://github.com/openstack/octavia/tree/master/elements/certs-ramfs
+#
+# Uninstall the kernel optimized for virtual instances to ensure the generic
+# kernel is used.
+#
 # note that we do this step here both because the uninstall property of
 # ``package-installs.yaml`` does not work properly with ``not-arch`` and
 # to make sure the generic kernel is the one used for boot.
 
-sudo apt remove -y --purge "linux-*-kvm"
+apt-get remove -y --purge linux-*kvm
+apt-get remove -y --purge linux-*virtual


### PR DESCRIPTION
The command used for removing kvm/virtual kernel packages to
ensure the generic kernel is used fails on Focal.

Also use the virtual ``linux-generic`` package for installation
instead of using the image package directly.

Fixes #21