### PR TITLE
Increase the size of image to make room for updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,5 @@ install:
   - sudo snap install --classic snapcraft
 env:
  - ENV=bashate
- - ENV=inspect
 script:
  - tox -e $ENV

--- a/src/retrofit/retrofit.sh
+++ b/src/retrofit/retrofit.sh
@@ -80,7 +80,7 @@ TEMP_IMAGE_NAME=$(echo ${TEMP_IMAGE_FILE}|cut -f1 -d\.)
 qemu-img convert -O raw $INPUT_IMAGE $TEMP_IMAGE_FILE
 
 if [ -n "$RESIZE" ]; then
-    qemu-img resize -f raw $TEMP_IMAGE_FILE +1G
+    qemu-img resize -f raw $TEMP_IMAGE_FILE +2G
 fi
 
 virt-dib ${DEBUG} \

--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,6 @@ deps =
 whitelist_externals = sh
 commands = sh -c "ls -1 src/retrofit/*.sh src/elements/*/*.d/* | xargs bashate"
 
-[testenv:inspect]
-whitelist_externals = snapcraft
-commands = snapcraft inspect
-
 [testenv:build-and-test]
 # Note that this is done to validate the ``snapcraft.yaml`` and build only.
 # actual building and publishing is handled on commit by https://build.snapcraft.io.


### PR DESCRIPTION
At this point in time attempting to retrofit a Focal image built
20200804 will fail due to the amount of updates being installed
exceeding the size of the root filesystem in the image.

We already resize the image and grow the root filesystem as part
of the process, increase the size we resize to to give more head
room.

Closes-Bug: #1893697