### PR TITLE
Add workaround for grub-efi-amd64-signed install failure on Focal

### DIFF
--- a/src/elements/bug1895835/pre-install.d/42-drop-grub-efi-pkgs
+++ b/src/elements/bug1895835/pre-install.d/42-drop-grub-efi-pkgs
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+# Remove EFI packages to work around LP: #1895835
+RELEASE=$(lsb_release -sc)
+if [ "$RELEASE"x = focalx ]; then
+    echo "Removing GRUB EFI packages to work around LP: #1895835..."
+    DEBIAN_FRONTEND=noninteractive apt-get remove \
+        --ignore-missing \
+        --purge \
+        -y \
+        grub-efi-amd64-bin grub-efi-amd64-signed
+fi

--- a/src/retrofit/retrofit.sh
+++ b/src/retrofit/retrofit.sh
@@ -105,7 +105,7 @@ virt-dib ${DEBUG} \
     ubuntu-cloud-archive ubuntu-ppa \
     haproxy-octavia rebind-sshd no-resolvconf amphora-agent \
     sos keepalived-octavia ipvsadmin pip-cache certs-ramfs \
-    ubuntu-amphora-agent tuning
+    ubuntu-amphora-agent tuning bug1895835
 
 virt-sysprep -a $TEMP_IMAGE_FILE \
     --operations tmp-files,customize \


### PR DESCRIPTION
Closes-Bug: #1895835