### PR TITLE
Disable predictable interface naming in amphora

### DIFF
--- a/src/elements/debian-networking/install.d/10-debian-networking
+++ b/src/elements/debian-networking/install.d/10-debian-networking
@@ -35,10 +35,14 @@ if [[ "${DIB_APT_MINIMAL_CREATE_INTERFACES:-1}" -eq "1" ]]; then
         echo "source /etc/network/interfaces.d/*" >> /etc/network/interfaces
         echo 'Network configuration set to source /etc/network/interfaces.d/*'
     fi
-    for interface in eth0 eth1; do
+    for interface in eth0; do
         cat << EOF | tee /etc/network/interfaces.d/$interface
 auto $interface
-iface $interface inet dhcp
+EOF
+    done
+    for interface in eth1; do
+        cat << EOF | tee /etc/network/interfaces.d/$interface
+allow-hotplug $interface
 EOF
     done
 fi

--- a/src/elements/debian-networking/pre-install.d/5-networkinterfacenames
+++ b/src/elements/debian-networking/pre-install.d/5-networkinterfacenames
@@ -1,0 +1,13 @@
+set -x
+set -eu
+set -o pipefail
+
+# The Octavia Amphora agent assumes eni and ifupdown on Ubuntu
+#
+# We have run into issues with using ifupdown in combination with
+# modern predictable interface naming schemes, let's disable until
+# the agent stops assuming ifupdown. LP: #1896729
+
+cat << EOF | tee /etc/default/grub.d/60-networkinterfacenames.cfg
+GRUB_CMDLINE_LINUX_DEFAULT="\$GRUB_CMDLINE_LINUX_DEFAULT biosdevname=0 net.ifnames=0"
+EOF


### PR DESCRIPTION
The Octavia Amphora agent expects to manage ifupdown eni type
configuration.

Bring up the first interface and let cloud-init complete the
networking configuration from config drive.