### PR TITLE
Force NTP synchronization only to ARM arch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -287,7 +287,9 @@ parts:
           mkdir /snap/$CRAFT_PROJECT_NAME/current/bin
       fi
       dpkg-source --before-build .
-      patch -p1 < $CRAFT_PROJECT_DIR/patch/patch-libguestfs-appliance-init-chrony.patch
+      if echo $CRAFT_TARGET_ARCH | grep -q ^arm; then
+          patch -p1 < $CRAFT_PROJECT_DIR/patch/patch-libguestfs-appliance-init-chrony.patch
+      fi
       patch -p1 < $CRAFT_PROJECT_DIR/patch/patch-libguestfs-appliance-init-link-up.patch
       autoreconf
       craftctl default


### PR DESCRIPTION
Follow-up to de967f6faa8ce86109ee09fb00fd7f7a2fb2e5d9.

There is no assurance of reachability to NTP servers on the internet (chrony has the default list of servers). When the retrofitting environment doesn't allow outbound NTP port access like being behind HTTP proxy. The image building process gets stuck at the phase of waiting for the time sync. As the original issue description suggests, on non ARM architectures, using time from the host is more than sufficient so let's not force NTP synchronization.

An ideal solution would be to accept a customized list of NTP servers for the future.

Partial-Bug: https://launchpad.net/bugs/1993266