### PR TITLE
Add workaround for grub-efi-amd64-signed install failure on Jammy+

### DIFF
--- a/src/elements/bug1895835/pre-install.d/42-drop-grub-efi-pkgs
+++ b/src/elements/bug1895835/pre-install.d/42-drop-grub-efi-pkgs
@@ -2,13 +2,17 @@
 
 set -e
 
-if [ "$DIB_RELEASE"x != jammyx ]; then
-    # Remove EFI packages to work around LP: #1895835
-    echo "Removing GRUB EFI packages to work around LP: #1895835..."
-    DEBIAN_FRONTEND=noninteractive apt-get remove \
-        --allow-remove-essential \
-        --ignore-missing \
-        --purge \
-        -y \
-        grub-efi-amd64-bin grub-efi-amd64-signed
-fi
+case $DIB_RELEASE in
+    bionic|focal) PKG_RM="grub-efi-amd64-bin grub-efi-amd64-signed";;
+    *) PKG_RM="grub-efi-amd64-bin grub-efi-amd64-signed shim-signed";;
+esac
+
+# Remove EFI packages to work around LP: #1895835
+echo "Removing GRUB EFI packages $PKG_RM"
+echo "to work around LP: #1895835..."
+DEBIAN_FRONTEND=noninteractive apt-get remove \
+    --allow-remove-essential \
+    --ignore-missing \
+    --purge \
+    -y \
+    $PKG_RM


### PR DESCRIPTION
The grub-efi-amd64-signed install failure that was identified on focal *1 now appears to be affecting Jammy. The workaround is very slightly different as the shim-signed package relies on grub-efi-amd64-signed so needs to be removed as well.

*1 https://bugs.launchpad.net/snap-octavia-diskimage-retrofit/+bug/1895835

Closes-Bug: 1995130