### PR TITLE
Don't leave the default set of archive servers

### DIFF
--- a/src/elements/ubuntu-archive/pre-install.d/02-ubuntu-archive
+++ b/src/elements/ubuntu-archive/pre-install.d/02-ubuntu-archive
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Add the Ubuntu mirror
+
+if [ ! -z "${DIB_UBUNTU_MIRROR}" ]; then
+    # disable the default set of archive servers
+    sed -i -e 's/^/# /' /etc/apt/sources.list
+
+    # DIB_UBUNTU_MIRROR may contain '\n' in the middle since multiple
+    # pockets are necessary to install packages properly
+    printf '%b\n' "$DIB_UBUNTU_MIRROR" >> /etc/apt/sources.list
+    apt-get update
+fi

--- a/src/elements/ubuntu-archive/pre-install.d/42-ubuntu-archive
+++ b/src/elements/ubuntu-archive/pre-install.d/42-ubuntu-archive
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Add the Ubuntu mirror
-
-if [ ! -z "${DIB_UBUNTU_MIRROR}" ]; then
-    add-apt-repository "$DIB_UBUNTU_MIRROR"
-    apt-get update
-fi

--- a/src/retrofit/retrofit.sh
+++ b/src/retrofit/retrofit.sh
@@ -6,12 +6,12 @@ NAME=$(basename $0)
 
 usage() {
     >&2 cat <<EOF
-$NAME: input output [-dhr] [-u Ubuntu Cloud Archive pocket] [-O output format]
+$NAME: [-dhr] [-u Ubuntu Cloud Archive pocket] [-O output format] input output
 
     -c    Specify Ubuntu Cloud Archive mirror (e.g. 'deb http://ppa.launchpad.net/ubuntu-cloud-archive/stein/ubuntu bionic main')
     -d    Enable verbose debugging output
     -h    Dislay help/usage
-    -m    Specify Ubuntu mirror (e.g. 'deb http://archive.ubuntu.com/ubuntu bionic main')
+    -m    Specify Ubuntu mirror (e.g. 'deb http://example.com/ubuntu jammy main universe\ndeb http://example.com/ubuntu jammy-security main universe\ndeb http://example.com/ubuntu jammy-updates main universe')
     -r    Do not resize image before retrofitting
     -u    Specify Ubuntu Cloud Archive pocket (e.g. 'yoga')
     -p    Specify PPA to add to image


### PR DESCRIPTION
Follow-up of https://github.com/openstack-charmers/octavia-diskimage-retrofit/commit/c39bef13eda60b605873a951a50ce0c48aa1c1a7.

If we don't disable it, the system uses both the default set of servers
and the mirror specified. It's not so harmful in fully online scenarios,
but it causes issues in air-gapped or restricted environments. By
leaving the default servers, the retrofitting process has to wait for
timeout for each component like DNS timeout for archive.ubuntu.com and
it makes the process longer than usual like from a few minutes to hours
unnecessarily.

Also, the step to disable those servers must be 02- or earlier since
03-baseline-tools already uses APT so the original 42- position was too
late. Furthermore, putting multi-line content into DIB_UBUNTU_MIRROR is
not ideal but it's necessary to keep the backward compatibility. It was
nicer if we leveraged DIB_DISTRIBUTION_MIRROR in
diskimage_builder/elements/ubuntu/pre-install.d/01-set-ubuntu-mirror and
DIB_DEBIAN_COMPONENTS in the first place.

Closes-Bug: https://launchpad.net/bugs/2011527