### PR TITLE
Fix ping healthmonitoring permission denied

### DIFF
--- a/src/elements/ubuntu-amphora-agent/post-install.d/42-ubuntu-amphora-agent
+++ b/src/elements/ubuntu-amphora-agent/post-install.d/42-ubuntu-amphora-agent
@@ -27,3 +27,5 @@ EOF
 # Let's retain a symlink so that the same Amphora can be used for multiple
 # versions.
 ln -sf lvs-masquerade.sh /usr/local/bin/udp-masquerade.sh
+
+chmod 755 /var/lib/octavia


### PR DESCRIPTION
Adjusted permissions of /var/lib/octavia
to allow access to the contents of the folder
and therefore to the ping-wrapper.sh file.

Closes: LP#2095432