### PR TITLE
Noble (24.04) support

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,58 @@
+name: Build and Test
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - uses: snapcore/action-build@v1
+      - name: Install the snap
+        run: |
+          sudo snap install --dangerous --classic ${{ steps.snapcraft.outputs.snap }}
+      - name: Get the Ubuntu Noble Image
+        run: |
+          sudo wget --continue -O /var/snap/octavia-diskimage-retrofit/common/tmp/noble.img \
+              https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img
+      - name: Retrofitting noble image
+        run: |
+          cd /var/snap/octavia-diskimage-retrofit/common/tmp
+          octavia-diskimage-retrofit -d noble.img noble-amphora.qcow2
+
+      - name: Test if the image can be booted
+        run: |
+          set -x
+          qemu-system-x86_64 \
+              -m 2G \
+              -drive file=/var/snap/octavia-diskimage-retrofit/common/tmp/noble-amphora.qcow2,format=qcow2 \
+              -nographic \
+              -serial mon:stdio,logfile=serial.log \
+              -display none \
+              -device virtio-net-pci,netdev=net0 \
+              -netdev user,id=net0,hostfwd=tcp::2222-:22 \
+              -accel kvm &
+
+          timeout 300 bash -c 'until nc -z localhost 2222; do echo -n .; sleep 5; done'
+
+          tail -n 5 serial.log
+          grep "login:" serial.log
+
+      - name: Upload built snap artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: snap
+          path: ${{ steps.snapcraft.outputs.snap }}
+          if-no-files-found: ignore
+      - name: Upload serial log artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: serial.log
+          path: serial.log
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Example Usage:
 
     sudo snap install --classic octavia-diskimage-retrofit
     cd /var/snap/octavia-diskimage-retrofit/common/tmp
-    wget https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img
+    wget https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img
     sudo octavia-diskimage-retrofit \
-        ubuntu-20.04-server-cloudimg-amd64.img \
+        ubuntu-24.04-server-cloudimg-amd64.img \
         ubuntu-amphora-haproxy-amd64.qcow2
 
 **NOTE** The tool will use KVM acceleration when available

--- a/patch/patch-libguestfs-appliance-add-dhcpcd-support-on-Debian.patch
+++ b/patch/patch-libguestfs-appliance-add-dhcpcd-support-on-Debian.patch
@@ -1,0 +1,36 @@
+From 91fab3f498b6847454656acd2f3d5788c533033b Mon Sep 17 00:00:00 2001
+From: Daniel Gomez <da.gomez@samsung.com>
+Date: Wed, 5 Feb 2025 09:10:31 +0000
+Subject: [PATCH] appliance: add dhcpcd support on Debian
+
+Debian has replaced the deprecated isc-dhcp-client (dhclient) with
+dhcpcd-base (dhcpcd) as the default DHCP client [1]. This causes network
+issues in virt-builder since isc-dhcp-client is no longer installed
+by default.
+
+Add support for dhcpcd (dhcpcd-base package) in Debian.
+
+[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1041066
+
+Signed-off-by: Daniel Gomez <da.gomez@samsung.com>
+---
+ appliance/packagelist.in | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/appliance/packagelist.in b/appliance/packagelist.in
+index 7b6e9f23f..2062f20bb 100644
+--- a/appliance/packagelist.in
++++ b/appliance/packagelist.in
+@@ -74,7 +74,9 @@ dnl iproute has been renamed to iproute2
+   iputils-ping
+   iputils-arping
+   iputils-tracepath
++dnl isc-dhcp-client has been replaced with dhcpcd-base
+   isc-dhcp-client
++  dhcpcd-base
+   ldmtool
+   libc-bin
+   librpm9
+-- 
+2.51.0
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -296,6 +296,7 @@ parts:
           patch -p1 < $CRAFT_PROJECT_DIR/patch/patch-libguestfs-appliance-init-chrony.patch
       fi
       patch -p1 < $CRAFT_PROJECT_DIR/patch/patch-libguestfs-appliance-init-link-up.patch
+      patch -p1 < $CRAFT_PROJECT_DIR/patch/patch-libguestfs-appliance-add-dhcpcd-support-on-Debian.patch
       autoreconf
       craftctl default
       rm -f /snap/$CRAFT_PROJECT_NAME/current

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,12 +21,12 @@ description: |
 
   **NOTE** The tool will use KVM acceleration when available.
 confinement: classic
-base: core22
-architectures:
-  - build-on: amd64
-  - build-on: arm64
-  - build-on: ppc64el
-  - build-on: s390x
+base: core24
+platforms:
+  amd64:
+  arm64:
+  ppc64el:
+  s390x:
 
 environment:
   # To enable execution of binaries from snap, and the host operating system,
@@ -46,7 +46,7 @@ environment:
   LIBGUESTFS_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/guestfs/appliance
   TMPDIR: $SNAP_COMMON/tmp
   PYTHONHOME: $SNAP
-  PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.10/site-packages:$SNAP/usr/lib/python3.10:$SNAP/usr/lib/python3.10/lib-dynload
+  PYTHONPATH: $SNAP/usr/local/lib/python3.12/dist-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12/site-packages:$SNAP/usr/lib/python3.12:$SNAP/usr/lib/python3.12/lib-dynload
 apps:
   octavia-diskimage-retrofit:
     command: bin/retrofit.sh
@@ -68,7 +68,7 @@ parts:
     plugin: dump
     source: https://git.launchpad.net/~ubuntu-openstack-dev/ubuntu/+source/octavia
     source-type: git
-    source-branch: stable/yoga
+    source-branch: stable/2024.1
     organize:
       elements/*: usr/local/lib/elements/
     stage:
@@ -81,11 +81,11 @@ parts:
     plugin: dump
     source: https://git.launchpad.net/~ubuntu-openstack-dev/ubuntu/+source/python-diskimage-builder
     source-type: git
-    source-branch: stable/yoga
+    source-branch: stable/2024.1
     build-environment:
       - PATH: $CRAFT_PART_INSTALL/usr/bin:$PATH
       - PYTHONHOME: $CRAFT_PART_INSTALL
-      - PYTHONPATH: $CRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$CRAFT_PART_INSTALL/usr/lib/python3.10/site-packages:$CRAFT_PART_INSTALL/usr/lib/python3.10:$CRAFT_PART_INSTALL/usr/lib/python3.10/lib-dynload
+      - PYTHONPATH: $CRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$CRAFT_PART_INSTALL/usr/lib/python3.12/site-packages:$CRAFT_PART_INSTALL/usr/lib/python3.12:$CRAFT_PART_INSTALL/usr/lib/python3.12/lib-dynload
     override-build: |
       patch -p1 < $CRAFT_PROJECT_DIR/patch/patch-diskimage-builder-manifests-fix-chown.patch
 
@@ -98,14 +98,13 @@ parts:
       find $CRAFT_PART_INSTALL -type f -print0 | xargs -0 sed -i '1 s/^#\!.*python3$/#\!\/usr\/bin\/env python3/'
       craftctl default
     stage-packages:
-      - libpython3.10
-      - libpython3.10-minimal
-      - libpython3.10-stdlib
+      - libpython3.12
+      - libpython3.12-minimal
+      - libpython3.12-stdlib
       - python3-minimal
-      - python3.10-minimal
+      - python3.12-minimal
       - python3-pip
       - python3-setuptools
-      - python3-distutils
       - python3-pkg-resources
       - python3-py
       - python3-babel
@@ -118,16 +117,18 @@ parts:
   qemu:
     source: https://git.launchpad.net/ubuntu/+source/qemu
     source-type: git
-    source-branch: ubuntu/jammy-updates
+    source-branch: ubuntu/noble-updates
     plugin: autotools
     build-attributes:
       - enable-patchelf
+    build-environment:
+      - PYTHON: /usr/bin/python3
     override-build: |
       dpkg-source --before-build .
       rm -rf build && mkdir build && cd build
       ../configure \
           --extra-cflags='-g -O2 -fdebug-prefix-map=/home/ubuntu/qemu-2.11+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -DVENDOR_UBUNTU' \
-          --extra-ldflags='-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,--as-needed -Wl,-dynamic-linker=/snap/core22/current/lib64/ld-linux-x86-64.so.2 -Wl,-rpath=/snap/core22/current/lib/x86_64-linux-gnu' \
+          --extra-ldflags='-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,--as-needed -Wl,-dynamic-linker=/snap/core24/current/lib64/ld-linux-x86-64.so.2 -Wl,-rpath=/snap/core24/current/lib/x86_64-linux-gnu' \
           --prefix=/snap/$CRAFT_PROJECT_NAME/current/usr \
           --bindir=bin \
           --libdir=lib/$CRAFT_ARCH_TRIPLET \
@@ -137,7 +138,7 @@ parts:
           --localstatedir=/var/snap/$CRAFT_PROJECT_NAME/common \
           --interp-prefix=/var/snap/$CRAFT_PROJECT_NAME/common/etc/qemu-binfmt/%M \
           --firmwarepath="/snap/$CRAFT_PROJECT_NAME/current/usr/share/qemu:/snap/$CRAFT_PROJECT_NAME/current/usr/share/seabios:/snap/$CRAFT_PROJECT_NAME/current/usr/lib/ipxe/qemu" \
-          --disable-blobs \
+          --disable-install-blobs \
           --disable-strip \
           --disable-user \
           --enable-modules \
@@ -154,16 +155,13 @@ parts:
           --disable-vnc \
           --disable-vnc-sasl \
           --disable-vnc-jpeg \
-          --disable-vnc-png \
           --disable-spice \
           --disable-curses \
           --disable-xen \
           --enable-seccomp \
-          --enable-xfsctl \
           --enable-kvm \
           --enable-vhost-net \
-          --target-list="aarch64-softmmu ppc64-softmmu riscv64-softmmu s390x-softmmu x86_64-softmmu" \
-          --with-git-submodules=ignore
+          --target-list="aarch64-softmmu ppc64-softmmu riscv64-softmmu s390x-softmmu x86_64-softmmu"
           make -j${CRAFT_PARALLEL_BUILD_COUNT}
           make install DESTDIR=${CRAFT_PART_INSTALL}
     build-packages:
@@ -184,7 +182,6 @@ parts:
       - libcapstone-dev
       - pkg-config
       - libpixman-1-dev
-      - python-all-dev
       - libglib2.0-dev
       - glusterfs-common
       - gnutls-dev
@@ -250,7 +247,7 @@ parts:
       - seabios
       - ipxe-qemu
       - libnuma1
-      - libaio1
+      - libaio1t64
       - libcapstone4
       - libfdt1
       - libpixman-1-0
@@ -262,6 +259,10 @@ parts:
       - libfdt1
       - libibverbs1
       - libslirp0
+      - libfuse3-3
+      - libgbm1
+      - libepoxy0
+      - libvirglrenderer1
       - qemu-system-data
       - on amd64:
         - libpmem1
@@ -275,7 +276,7 @@ parts:
     after: [qemu]
     source: https://git.launchpad.net/ubuntu/+source/libguestfs
     source-type: git
-    source-tag: ubuntu/jammy
+    source-branch: ubuntu/jammy
     plugin: autotools
     build-attributes:
       - enable-patchelf
@@ -317,10 +318,8 @@ parts:
       root/stage/: /
     autotools-configure-parameters:
       - --disable-silent-rules
-      - --disable-gnulib-tests
       - --with-readline
       - --disable-haskell
-      - --disable-java
       - --disable-golang
       - --disable-python
       - --disable-perl
@@ -364,7 +363,7 @@ parts:
       - fdisk
       - file
       - flex
-      - libfuse2
+      - libfuse2t64
       - libfuse-dev
       - gawk
       - gdisk
@@ -412,6 +411,7 @@ parts:
       - libtest-pod-coverage-perl
       - libtest-pod-perl
       - libtool
+      - libtirpc-dev
       - libtsk-dev
       - libxml2-dev
       - libxml2-utils
@@ -461,6 +461,7 @@ parts:
       - libgettext-ocaml-dev
       - libhivex-ocaml-dev
       - libounit-ocaml-dev
+      - libaugeas-ocaml-dev
       - libvirt-ocaml-dev
       - ocaml-findlib
       - ocaml-nox
@@ -480,16 +481,17 @@ parts:
       - libmagic1
       - uuid-runtime
       - libjansson4
-      - libfuse2
+      - libfuse2t64
       - libfuse3-3
       - fuse3
+      - libtirpc3t64
     stage:
       - -lib64
   guestfs-tools:
     after: [libguestfs]
-    source: https://salsa.debian.org/libvirt-team/guestfs-tools.git
+    source: https://git.launchpad.net/ubuntu/+source/guestfs-tools
     source-type: git
-    source-tag: debian/1.46.1-4
+    source-branch: ubuntu/jammy
     plugin: autotools
     build-attributes:
       - enable-patchelf
@@ -561,7 +563,7 @@ parts:
       - findutils
       - grep
       - util-linux
-      - libicu70
+      - libicu74
       - libxml2
       - libc-bin
       - lsb-release

--- a/src/elements/tuning/package-installs.yaml
+++ b/src/elements/tuning/package-installs.yaml
@@ -1,4 +1,3 @@
 sysstat:
 htop:
 ifstat:
-dstat:

--- a/src/elements/ubuntu-archive/pre-install.d/02-ubuntu-archive
+++ b/src/elements/ubuntu-archive/pre-install.d/02-ubuntu-archive
@@ -11,3 +11,10 @@ if [ ! -z "${DIB_UBUNTU_MIRROR}" ]; then
     printf '%b\n' "$DIB_UBUNTU_MIRROR" >> /etc/apt/sources.list
     apt-get update
 fi
+
+# Enable the 'universe' component for Ubuntu Noble and later, where packages
+# such as amphora-agent are no longer in 'main' but in 'universe'.
+if [[ "${DIB_RELEASE}" > "mantic" ]]; then
+    add-apt-repository -y universe
+    apt-get update
+fi

--- a/src/retrofit/retrofit.sh
+++ b/src/retrofit/retrofit.sh
@@ -89,6 +89,7 @@ HOME=${SNAP_COMMON} virt-dib ${DEBUG} \
     -p $SNAP/usr/local/lib/python3.12/dist-packages/diskimage_builder/elements \
     -p $SNAP/usr/local/lib/elements \
     --formats raw \
+    --network \
     --name $TEMP_IMAGE_NAME \
     --envvar DISTRO_NAME=ubuntu \
     --envvar DIB_PYTHON_VERSION=3 \

--- a/src/retrofit/retrofit.sh
+++ b/src/retrofit/retrofit.sh
@@ -13,7 +13,7 @@ $NAME: [-dhr] [-u Ubuntu Cloud Archive pocket] [-O output format] input output
     -h    Dislay help/usage
     -m    Specify Ubuntu mirror (e.g. 'deb http://example.com/ubuntu jammy main universe\ndeb http://example.com/ubuntu jammy-security main universe\ndeb http://example.com/ubuntu jammy-updates main universe')
     -r    Do not resize image before retrofitting
-    -u    Specify Ubuntu Cloud Archive pocket (e.g. 'yoga')
+    -u    Specify Ubuntu Cloud Archive pocket (e.g. 'caracal')
     -p    Specify PPA to add to image
     -O    Specify output format (default: 'qcow2')
 EOF
@@ -65,7 +65,7 @@ fi
 
 # Set defaults
 DIB_UBUNTU_MIRROR=${DIB_UBUNTU_MIRROR:-""}
-DIB_UBUNTU_CLOUD_ARCHIVE=${DIB_UBUNTU_CLOUD_ARCHIVE:-yoga}
+DIB_UBUNTU_CLOUD_ARCHIVE=${DIB_UBUNTU_CLOUD_ARCHIVE:-caracal}
 DIB_UBUNTU_CLOUD_ARCHIVE_MIRROR=${DIB_UBUNTU_CLOUD_ARCHIVE_MIRROR:-""}
 DIB_UBUNTU_PPA=${DIB_UBUNTU_PPA:-""}
 DIB_OCTAVIA_AMP_USE_NFTABLES=${DIB_OCTAVIA_AMP_USE_NFTABLES:-False}
@@ -85,8 +85,8 @@ if [ "$RESIZE" != " " ]; then
 fi
 
 HOME=${SNAP_COMMON} virt-dib ${DEBUG} \
-    -B $SNAP/usr/lib/python3.10/site-packages/diskimage_builder/lib \
-    -p $SNAP/usr/lib/python3.10/site-packages/diskimage_builder/elements \
+    -B $SNAP/usr/local/lib/python3.12/dist-packages/diskimage_builder/lib \
+    -p $SNAP/usr/local/lib/python3.12/dist-packages/diskimage_builder/elements \
     -p $SNAP/usr/local/lib/elements \
     --formats raw \
     --name $TEMP_IMAGE_NAME \

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,8 @@ allowlist_externals =
   /snap/bin/snapcraft
   /usr/bin/sudo
 commands =
-    snapcraft pack {posargs:--use-lxd} -o built.snap
-    sudo snap install --dangerous --devmode built.snap
+    snapcraft pack -v {posargs:--use-lxd} -o built.snap
+    sudo snap install --dangerous --classic built.snap
     sudo snap connect octavia-diskimage-retrofit:fuse-support
     sudo snap connect octavia-diskimage-retrofit:kvm
     sudo wget -O /var/snap/octavia-diskimage-retrofit/common/tmp/noble.img https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,6 @@ allowlist_externals =
 commands =
     snapcraft pack -v {posargs:--use-lxd} -o built.snap
     sudo snap install --dangerous --classic built.snap
-    sudo snap connect octavia-diskimage-retrofit:fuse-support
-    sudo snap connect octavia-diskimage-retrofit:kvm
-    sudo wget -O /var/snap/octavia-diskimage-retrofit/common/tmp/noble.img https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img
+    sudo wget --continue -O /var/snap/octavia-diskimage-retrofit/common/tmp/noble.img https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img
     echo "Retrofitting noble image"
     sudo sh -c "cd /var/snap/octavia-diskimage-retrofit/common/tmp && octavia-diskimage-retrofit noble.img noble-amphora.qcow2"

--- a/tox.ini
+++ b/tox.ini
@@ -3,30 +3,37 @@ skipsdist = True
 envlist = bashate,build-and-test
 
 [testenv]
-setenv = VIRTUAL_ENV={envdir}
-         PYTHONHASHSEED=0
-passenv = http_proxy https_proxy HTTP_PROXY HTTPS_PROXY SNAPCRAFT_PROVIDER
+setenv = 
+    VIRTUAL_ENV={envdir}
+    PYTHONHASHSEED=0
+passenv =
+    http_proxy
+    https_proxy
+    HTTP_PROXY
+    HTTPS_PROXY
+    SNAPCRAFT_PROVIDER
 install_command =
     pip install {opts} {packages}
 deps =
     -r{toxinidir}/test-requirements.txt
 
 [testenv:bashate]
-allowlist_externals = /bin/sh
+allowlist_externals =
+    /bin/sh
 commands = sh -c "ls -1 src/retrofit/*.sh src/elements/*/*.d/* | xargs bashate"
 
 [testenv:build-and-test]
 # Note that this is done to validate the ``snapcraft.yaml`` and build only.
 # actual building and publishing is handled on commit by https://build.snapcraft.io.
-allowlist_externals = /usr/bin/echo /snap/bin/snapcraft /usr/bin/sudo
+allowlist_externals =
+  /usr/bin/echo
+  /snap/bin/snapcraft
+  /usr/bin/sudo
 commands =
-    snapcraft snap --provider={env:SNAPCRAFT_PROVIDER:lxd} -o built.snap
+    snapcraft pack {posargs:--use-lxd} -o built.snap
     sudo snap install --dangerous --devmode built.snap
     sudo snap connect octavia-diskimage-retrofit:fuse-support
     sudo snap connect octavia-diskimage-retrofit:kvm
-    sudo wget -O /var/snap/octavia-diskimage-retrofit/common/tmp/bionic.img https://cloud-images.ubuntu.com/releases/bionic/release/ubuntu-18.04-server-cloudimg-amd64.img
-    sudo wget -O /var/snap/octavia-diskimage-retrofit/common/tmp/focal.img https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img
-    echo "Retrofitting bionic image"
-    sudo sh -c "cd /var/snap/octavia-diskimage-retrofit/common/tmp && octavia-diskimage-retrofit bionic.img bionic-amphora.qcow2"
-    echo "Retrofitting focal image"
-    sudo sh -c "cd /var/snap/octavia-diskimage-retrofit/common/tmp && octavia-diskimage-retrofit focal.img focal-amphora.qcow2"
+    sudo wget -O /var/snap/octavia-diskimage-retrofit/common/tmp/noble.img https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img
+    echo "Retrofitting noble image"
+    sudo sh -c "cd /var/snap/octavia-diskimage-retrofit/common/tmp && octavia-diskimage-retrofit noble.img noble-amphora.qcow2"

--- a/tox.ini
+++ b/tox.ini
@@ -34,4 +34,4 @@ commands =
     sudo snap install --dangerous --classic built.snap
     sudo wget --continue -O /var/snap/octavia-diskimage-retrofit/common/tmp/noble.img https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img
     echo "Retrofitting noble image"
-    sudo sh -c "cd /var/snap/octavia-diskimage-retrofit/common/tmp && octavia-diskimage-retrofit noble.img noble-amphora.qcow2"
+    sudo sh -c "cd /var/snap/octavia-diskimage-retrofit/common/tmp && octavia-diskimage-retrofit -d noble.img noble-amphora.qcow2"


### PR DESCRIPTION
Update the snap to build and run correctly against Ubuntu Noble cloud
images as well as continuing to support Jammy images.

Snap build changes:
- Bump base from core22 to core24 and switch architectures to the
  platforms: syntax required by snapcraft 8.x
- Update Python references from 3.10 to 3.12 throughout (PYTHONPATH,
  stage-packages, build-environment)
- Update octavia and diskimage-builder source branches from stable/yoga
  to stable/2024.1
- Update QEMU source branch to ubuntu/noble-updates and adjust configure
  flags for Noble (rename --disable-blobs → --disable-install-blobs,
  drop --enable-xfsctl, --disable-vnc-png, --with-git-submodules)
- Switch libguestfs from source-tag to source-branch ubuntu/jammy
- Add missing Noble build/stage packages: libtirpc-dev, libtirpc3t64,
  libaugeas-ocaml-dev, libfuse2t64 (replaces libfuse2), libicu74
  (replaces libicu70), libaio1t64 (replaces libaio1), libfuse3-3,
  libgbm1, libepoxy0, libvirglrenderer1
- Drop python-all-dev, python3-distutils (removed in Noble)
- Drop --disable-gnulib-tests and --disable-java autotools flags
- Switch guestfs-tools source to Ubuntu Launchpad mirror on jammy branch
- Add PYTHON env var for QEMU build

Element and retrofit changes:
- ubuntu-archive/pre-install.d/02-ubuntu-archive: enable the universe
  component for Noble and later releases (where packages like
  amphora-agent are no longer in main)
- tuning/package-installs.yaml: drop dstat (removed in Noble)
- retrofit.sh: update default Ubuntu Cloud Archive pocket from yoga to
  caracal; update diskimage-builder lib/elements paths to python3.12
- tox.ini: pass -v to snapcraft pack and use --classic instead of
  --devmode; update test image download URL to Noble

libguestfs appliance fix:
- patch-libguestfs-appliance-add-dhcpcd-support-on-Debian.patch: backport
  support for newer Debian/Ubuntu

Fixes: https://bugs.launchpad.net/snap-octavia-diskimage-retrofit/+bug/2126902
Co-authored-by: GitHub Copilot <copilot@github.com>