### PR TITLE
snap: fix qemu build on non-amd64 architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -126,10 +126,15 @@ parts:
       - PYTHON: /usr/bin/python3
     override-build: |
       dpkg-source --before-build .
+      # Derive dynamic linker and rpath for the build host architecture so
+      # the configure sanity-check binary (and final binaries) use the correct
+      # interpreter on every supported platform (amd64, arm64, ppc64el, s390x).
+      DYNAMIC_LINKER=$(patchelf --print-interpreter /bin/sh | sed 's|^/lib|/snap/core24/current/lib|')
+      RPATH=/snap/core24/current/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}
       rm -rf build && mkdir build && cd build
       ../configure \
           --extra-cflags='-g -O2 -fdebug-prefix-map=/home/ubuntu/qemu-2.11+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -DVENDOR_UBUNTU' \
-          --extra-ldflags='-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,--as-needed -Wl,-dynamic-linker=/snap/core24/current/lib64/ld-linux-x86-64.so.2 -Wl,-rpath=/snap/core24/current/lib/x86_64-linux-gnu' \
+          --extra-ldflags="-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,--as-needed -Wl,-dynamic-linker=${DYNAMIC_LINKER} -Wl,-rpath=${RPATH}" \
           --prefix=/snap/$CRAFT_PROJECT_NAME/current/usr \
           --bindir=bin \
           --libdir=lib/$CRAFT_ARCH_TRIPLET \
@@ -166,6 +171,7 @@ parts:
           make -j${CRAFT_PARALLEL_BUILD_COUNT}
           make install DESTDIR=${CRAFT_PART_INSTALL}
     build-packages:
+      - patchelf
       - libaio-dev
       - libattr1-dev
       - libcap-dev


### PR DESCRIPTION
The --extra-ldflags in the qemu part hardcoded x86-64-specific paths for the ELF dynamic linker and rpath:

  -Wl,-dynamic-linker=/snap/core24/current/lib64/ld-linux-x86-64.so.2
  -Wl,-rpath=/snap/core24/current/lib/x86_64-linux-gnu

When building on arm64 (or other architectures), meson compiles a sanity-check binary during configure and tries to execute it.  Because the binary was linked against the non-existent x86-64 interpreter, the kernel returns ENOENT and meson setup fails with:

  Could not invoke sanity test executable: [Errno 2] No such file or directory

Fix by computing the correct dynamic linker path and rpath at build time using patchelf and $CRAFT_ARCH_TRIPLET_BUILD_FOR, so each architecture gets its own interpreter and library directory.

Assisted-by: GitHub Copilot